### PR TITLE
Optional SSH commands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 FROM alpine
-RUN apk update && apk add bash openssh
+RUN apk update && apk --no-cache add openssh
 COPY entrypoint.sh /
 RUN chmod +x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
-

--- a/README.md
+++ b/README.md
@@ -6,10 +6,15 @@ Transfer files to remote host over SSH/SCP using key based authentication.
 
 - `host`: Remote host name or ip address
 - `username`: Username for login
-- `port`: Port used for SSH connection
 - `key`: SSH private key
 - `source`: Source files or directories
 - `target`: Remote path location
+
+## Optional arguments
+
+- `port`: Port used for SSH connection (Default: 22)
+- `before`: commands to run before copying files
+- `after`: commands to run after copying files
 
 ## SSH authentication and configuration
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Transfer files to remote host over SSH/SCP using key based authentication.
 
 ## SSH authentication and configuration
 
-Password auehtentication is considered unsecure and is not implemented.
+Password authentication is considered unsecure and is not implemented.
 
 SSH key generation is done as follows:
 ```

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,6 @@
-name: 'SCP Uploader'
+name: 'SCP Uploader (Fork)'
 description: 'Deploy/upload files via SSH using key based authentication'
-author: 'Moonpath'
+author: 'ErSoul'
 inputs:
   host:
     description: 'remote host'

--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,12 @@ inputs:
   target:
     description: 'destination path'
     required: false
+  before:
+    description: 'command to execute before transfer'
+    required: false
+  after:
+    description: 'command to execute after transfer'
+    required: false
 
 runs:
   using: 'docker'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,10 +1,17 @@
-#!/bin/bash
+#!/bin/sh
+
+set -e
+
 echo "Saving key to file..."
-echo -e "${INPUT_KEY}" > key.txt
+echo "${INPUT_KEY}" > key.txt
 
 echo "Set key file access rights..."
 chmod 600 key.txt
 
+[ -n "$INPUT_BEFORE" ] && ssh -v -p $INPUT_PORT -o StrictHostKeyChecking=no -i key.txt "$INPUT_USERNAME"@"$INPUT_HOST" "$INPUT_BEFORE"
+
 echo "Starting SCP process..."
-scp -pqrv -P $INPUT_PORT -o StrictHostKeyChecking=no -i key.txt $INPUT_SOURCE "$INPUT_USERNAME"@"$INPUT_HOST":"$INPUT_TARGET" || exit 1
+scp -pqrv -P $INPUT_PORT -o StrictHostKeyChecking=no -i key.txt $INPUT_SOURCE "$INPUT_USERNAME"@"$INPUT_HOST":"$INPUT_TARGET"
 echo "SCP operation completeted."
+
+[ -n "$INPUT_AFTER" ] && ssh -v -p $INPUT_PORT -o StrictHostKeyChecking=no -i key.txt "$INPUT_USERNAME"@"$INPUT_HOST" "$INPUT_AFTER"


### PR DESCRIPTION
Removed bash. No reason not to use the POSIX shell. And alpine's `ash` should be enough.

Added two optional inputs. Can be used as contextual instructions for the files transferred.